### PR TITLE
Remove deprecated tts dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,6 @@ RUN apt-get update && \
     espeak-ng \
     git  # Added to handle installing plugins from git
 
-# Install TTS for Coqui plugin here to reduce time and layer size
-RUN pip install tts==0.6.2
-
-
 ADD . /neon_audio
 WORKDIR /neon_audio
 


### PR DESCRIPTION
Remove installation of TTS package in Docker container now that Coqui plugin removed this dependency