### PR TITLE
Fix isSpeaking signal creation

### DIFF
--- a/neon_audio/__main__.py
+++ b/neon_audio/__main__.py
@@ -31,7 +31,7 @@ from neon_utils.configuration_utils import init_config_dir
 from neon_utils.logger import LOG
 
 from mycroft.lock import Lock
-from ovos_config import setup_locale
+from ovos_config.locale import setup_locale
 
 
 def main(*args, **kwargs):

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -27,6 +27,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import mycroft.audio.tts
+import ovos_plugin_manager.templates.tts
 
 from neon_utils.logger import LOG
 from neon_audio.tts import TTSFactory
@@ -75,13 +76,20 @@ class NeonPlaybackService(PlaybackService):
             LOG.info("Updating global config with passed config")
             from neon_audio.utils import patch_config
             patch_config(audio_config)
+
+        # Override all the previously loaded signal methods
+        from neon_utils.signal_utils import init_signal_handlers, \
+            init_signal_bus
+        init_signal_bus(bus)
+        init_signal_handlers()
+        from neon_utils.signal_utils import create_signal, check_for_signal
+        mycroft.audio.service.check_for_signal = check_for_signal
+        ovos_plugin_manager.templates.tts.check_for_signal = check_for_signal
+        ovos_plugin_manager.templates.tts.create_signal = create_signal
+
         PlaybackService.__init__(self, ready_hook, error_hook, stopping_hook,
                                  alive_hook, started_hook, watchdog, bus)
         self.setDaemon(daemonic)
-        from neon_utils.signal_utils import init_signal_handlers, \
-            init_signal_bus
-        init_signal_bus(self.bus)
-        init_signal_handlers()
 
     def handle_speak(self, message):
         message.context.setdefault('destination', [])

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -31,6 +31,8 @@ import ovos_plugin_manager.templates.tts
 
 from neon_utils.logger import LOG
 from neon_audio.tts import TTSFactory
+from neon_utils.messagebus_utils import get_messagebus
+
 mycroft.audio.tts.TTSFactory = TTSFactory
 
 from mycroft.audio.service import PlaybackService
@@ -76,7 +78,7 @@ class NeonPlaybackService(PlaybackService):
             LOG.info("Updating global config with passed config")
             from neon_audio.utils import patch_config
             patch_config(audio_config)
-
+        bus = bus or get_messagebus()
         # Override all the previously loaded signal methods
         from neon_utils.signal_utils import init_signal_handlers, \
             init_signal_bus

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -258,6 +258,9 @@ class WrappedTTS(TTS):
             TTS engine get_tts method
         """
         if message:
+            # Make sure to set the speaking signal now
+            if not message.context.get("klat_data"):
+                create_signal("isSpeaking")
             # TODO: Should sentence and ident be added to message context? DM
             message.data["text"] = sentence
             responses = self.get_multiple_tts(message, **kwargs)
@@ -271,7 +274,6 @@ class WrappedTTS(TTS):
                                     {"responses": responses,
                                      "speaker": message.data.get("speaker")}))
             else:
-                create_signal("isSpeaking")
                 # Local user has multiple configured languages (or genders)
                 for r in responses.values():
                     # get audio for selected voice gender


### PR DESCRIPTION
Create `isSpeaking` signal before TTS calls to ensure audio is awaited properly