### PR TITLE
Install CPU-only pytorch from official source to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ADD . /neon_audio
 WORKDIR /neon_audio
 
 RUN pip install wheel && \
+    pip install torch --extra-index-url https://download.pytorch.org/whl/cpu && \
     pip install .[docker]
 
 COPY docker_overlay/ /


### PR DESCRIPTION
# Description
Install CPU-only torch to reduce image size per @NeonBohdan suggestion.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Should improve image download delays as reported by @NeonDmitry 