### PR TITLE
Pass torch index to dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ ADD . /neon_audio
 WORKDIR /neon_audio
 
 RUN pip install wheel && \
-    pip install torch --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip install .[docker]
+    pip install .[docker] --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY docker_overlay/ /
 RUN chmod ugo+x /root/run.sh


### PR DESCRIPTION
# Description
Replace unpinned torch installation with extra index passed to standard dependency installation

# Issues
Follow-up to #114 
Incorporate bugfix from https://github.com/NeonGeckoCom/neon_speech/pull/130

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->