### PR TITLE
Optimize module init

### DIFF
--- a/neon_audio/__main__.py
+++ b/neon_audio/__main__.py
@@ -27,31 +27,32 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from neon_utils.messagebus_utils import get_messagebus
-from neon_utils.configuration_utils import init_config_dir
 from neon_utils.log_utils import init_log
 from neon_utils.process_utils import start_malloc, snapshot_malloc, print_malloc
+from neon_utils.signal_utils import init_signal_bus, \
+    init_signal_handlers, check_for_signal
 from ovos_utils import wait_for_exit_signal
 from ovos_utils.log import LOG
 from ovos_config.locale import setup_locale
 from ovos_utils.process_utils import reset_sigint_handler, PIDLock as Lock
+
+from neon_audio.service import NeonPlaybackService
 
 
 def main(*args, **kwargs):
     if kwargs.get("config"):
         LOG.warning("Found `config` kwarg, but expect `audio_config`")
         kwargs["audio_config"] = kwargs.pop("config")
-
-    init_config_dir()
+    if kwargs.get("audio_config"):
+        LOG.warning("Passed configuration should be written to disk before"
+                    "module launch")
     init_log(log_name="audio")
     malloc_running = start_malloc(stack_depth=4)
     bus = get_messagebus()
     kwargs["bus"] = bus
-    from neon_utils.signal_utils import init_signal_bus, \
-        init_signal_handlers, check_for_signal
+
     init_signal_bus(bus)
     init_signal_handlers()
-
-    from neon_audio.service import NeonPlaybackService
 
     reset_sigint_handler()
     check_for_signal("isSpeaking")

--- a/neon_audio/cli.py
+++ b/neon_audio/cli.py
@@ -30,6 +30,7 @@ import click
 
 from click_default_group import DefaultGroup
 from neon_utils.packaging_utils import get_package_version_spec
+from neon_utils.configuration_utils import init_config_dir
 from ovos_config.config import Configuration
 
 
@@ -53,6 +54,7 @@ def neon_audio_cli(version: bool = False):
 @click.option("--force-install", "-f", default=False, is_flag=True,
               help="Force pip installation of configured module")
 def run(module, package, force_install):
+    init_config_dir()
     from neon_audio.__main__ import main
     audio_config = Configuration()
     if force_install or module or package:

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -33,9 +33,10 @@ from threading import Event
 from ovos_utils.log import LOG
 from neon_audio.tts import TTSFactory
 from neon_utils.messagebus_utils import get_messagebus
+from ovos_audio.service import PlaybackService
 
 ovos_audio.tts.TTSFactory = TTSFactory
-from ovos_audio.service import PlaybackService
+ovos_audio.service.TTSFactory = TTSFactory
 
 
 def on_ready():

--- a/neon_audio/utils.py
+++ b/neon_audio/utils.py
@@ -38,7 +38,7 @@ def patch_config(config: dict = None):
     """
     from ovos_config.config import LocalConf
     from ovos_config.locations import USER_CONFIG
-
+    LOG.warning(f"Patching configuration with: {config}")
     config = config or dict()
     local_config = LocalConf(USER_CONFIG)
     local_config.update(config)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-audio~=0.0.1,>=0.0.2a11
+ovos-audio~=0.0.1,>=0.0.2a12
 ovos-utils~=0.0.32
 ovos-config~=0.0.7
 phoneme-guesser~=0.1


### PR DESCRIPTION
# Description
Refactor module init to skip meta-config in most cases
Update ovos_audio to enable skipping fallback TTS init

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->