### PR TITLE
Pin ovos-audio dependency to resolve ident handling issue

### DIFF
--- a/docker_overlay/etc/neon/neon.yaml
+++ b/docker_overlay/etc/neon/neon.yaml
@@ -4,6 +4,8 @@ play_ogg_cmdline: "play %1"
 tts:
   module: coqui
   fallback_module: ovos-tts-plugin-mimic
+g2p:
+  module: dummy
 Audio:
   backends:
     OCP:

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -135,6 +135,11 @@ class NeonPlaybackThread(PlaybackThread):
 
     def _play(self):
         ident = self._now_playing[3]
+        if not ident and len(self._now_playing) >= 5 and \
+                isinstance(self._now_playing[4], Message):
+            LOG.debug("Handling new style playback")
+            ident = self._now_playing[4].context.get('session',
+                                                     {}).get('session_id')
         super()._play()
         LOG.info(f"Played {ident}")
         self.bus.emit(Message(ident))

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -133,7 +133,6 @@ def get_requested_tts_languages(msg) -> list:
 class NeonPlaybackThread(PlaybackThread):
     def __init__(self, queue):
         PlaybackThread.__init__(self, queue)
-        init_signal_bus(self.bus)
 
     def begin_audio(self, message=None):
         # TODO: Mark signals for deprecation
@@ -203,6 +202,7 @@ class WrappedTTS(TTS):
         if TTS.playback:
             TTS.playback.shutdown()
 
+        init_signal_bus(self.bus)
         TTS.playback = NeonPlaybackThread(TTS.queue)
         TTS.playback.set_bus(self.bus)
         TTS.playback.attach_tts(self)
@@ -337,4 +337,5 @@ class WrappedTTS(TTS):
         else:
             LOG.warning(f'no Message associated with TTS request: {ident}')
             assert isinstance(self, TTS)
+            create_signal("isSpeaking")
             TTS.execute(self, sentence, ident, listen, **kwargs)

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -40,7 +40,8 @@ from ovos_utils.enclosure.api import EnclosureAPI
 
 from neon_utils.file_utils import encode_file_to_base64_string
 from neon_utils.message_utils import resolve_message
-from neon_utils.signal_utils import create_signal, check_for_signal
+from neon_utils.signal_utils import create_signal, check_for_signal,\
+    init_signal_bus
 from ovos_utils.log import LOG
 
 from ovos_config.config import Configuration
@@ -132,6 +133,7 @@ def get_requested_tts_languages(msg) -> list:
 class NeonPlaybackThread(PlaybackThread):
     def __init__(self, queue):
         PlaybackThread.__init__(self, queue)
+        init_signal_bus(self.bus)
 
     def begin_audio(self, message=None):
         # TODO: Mark signals for deprecation

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -40,7 +40,7 @@ from ovos_utils.enclosure.api import EnclosureAPI
 
 from neon_utils.file_utils import encode_file_to_base64_string
 from neon_utils.message_utils import resolve_message
-from neon_utils.signal_utils import create_signal
+from neon_utils.signal_utils import create_signal, check_for_signal
 from ovos_utils.log import LOG
 
 from ovos_config.config import Configuration
@@ -132,6 +132,17 @@ def get_requested_tts_languages(msg) -> list:
 class NeonPlaybackThread(PlaybackThread):
     def __init__(self, queue):
         PlaybackThread.__init__(self, queue)
+
+    def begin_audio(self, message=None):
+        # TODO: Mark signals for deprecation
+        check_for_signal("isSpeaking")
+        create_signal("isSpeaking")
+        PlaybackThread.begin_audio(self, message)
+
+    def end_audio(self, listen, message=None):
+        PlaybackThread.end_audio(self, listen, message)
+        # TODO: Mark signals for deprecation
+        check_for_signal("isSpeaking")
 
     def _play(self):
         ident = self._now_playing[3]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,11 +1,10 @@
 ovos-audio~=0.0.1,>=0.0.2a12,<0.0.2a14
 # TODO: ovos-audio 0.0.2a14 introduces a breaking change around `ident` handling
-ovos-utils~=0.0.32
+ovos-utils~=0.0.34
 ovos-config~=0.0.7
 phoneme-guesser~=0.1
-# TODO: OPM 0.0.24a1 introduces breaking changes around signals
-ovos-plugin-manager~=0.0.22,<=0.0.23
-neon-utils[network]~=1.4,>=1.5.1a7
+ovos-plugin-manager~=0.0.22,>=0.0.24a5
+neon-utils[network]~=1.6
 click~=8.0
 click-default-group~=1.2
 ovos-bus-client~=0.0.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
-ovos-audio~=0.0.1,>=0.0.2a12
+ovos-audio~=0.0.1,>=0.0.2a12,<0.0.2a14
+# TODO: ovos-audio 0.0.2a14 introduces a breaking change around `ident` handling
 ovos-utils~=0.0.32
 ovos-config~=0.0.7
 phoneme-guesser~=0.1

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,4 +1,3 @@
 neon-tts-plugin-larynx-server~=0.1
 neon-lang-plugin-libretranslate~=0.1,>=0.1.2
-pytest
-mock~=4.0
+pytest~=7.2

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            # TODO: Deprecate neon_audio_client entrypoint
             'neon_audio_client=neon_audio.__main__:main',
             'neon-audio=neon_audio.cli:neon_audio_cli'
         ]

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -53,6 +53,7 @@ class TestAPIMethods(unittest.TestCase):
         use_neon_audio(init_config_dir)()
 
         test_config = Configuration()
+        test_config["g2p"]["module"] = "dummy"
         test_config["tts"]["module"] = "neon-tts-plugin-larynx-server"
         test_config["tts"]["neon-tts-plugin-larynx-server"] = \
             {"host": os.environ.get("TTS_URL") or "https://larynx.2022.us/"}

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -45,8 +45,8 @@ _TEST_CONFIG = {
     "g2p": {"module": "dummy"},
     "Audio": {},
     "tts": {"module": "neon-tts-plugin-larynx-server",
-            "neon-tts-plugin-larynx-server": {
-                "host": os.environ.get("TTS_URL") or "https://larynx.2022.us/"}}
+            "neon-tts-plugin-larynx-server": {"host": "https://larynx.2022.us/"}
+            }
 }
 
 
@@ -77,7 +77,6 @@ class TestAPIMethods(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        super(TestAPIMethods, cls).tearDownClass()
         try:
             cls.audio_service.shutdown()
         except Exception as e:

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -57,14 +57,12 @@ class TestAPIMethods(unittest.TestCase):
         use_neon_audio(init_config_dir)()
 
         test_config = Configuration()
-        test_config["g2p"] = {"module": None}
+        test_config["g2p"] = {"module": "dummy"}
         test_config["tts"]["module"] = "neon-tts-plugin-larynx-server"
         test_config["tts"]["neon-tts-plugin-larynx-server"] = \
             {"host": os.environ.get("TTS_URL") or "https://larynx.2022.us/"}
         assert test_config["tts"]["module"] == "neon-tts-plugin-larynx-server"
 
-        # cls.messagebus = NeonBusService(debug=True, daemonic=True)
-        # cls.messagebus.start()
         cls.audio_service = NeonPlaybackService(audio_config=test_config,
                                                 daemonic=True, bus=cls.bus)
         cls.audio_service.start()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -56,7 +56,9 @@ class TTSBaseClassTests(unittest.TestCase):
     test_conf_dir = join(dirname(__file__), "config")
 
     @classmethod
-    def setUpClass(cls) -> None:
+    @patch("ovos_plugin_manager.templates.tts.Configuration")
+    def setUpClass(cls, config) -> None:
+        config.return_value = cls.config  # Explicitly no g2p
         os.makedirs(cls.test_conf_dir, exist_ok=True)
         os.environ["XDG_CACHE_HOME"] = cls.test_cache_dir
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -50,14 +50,16 @@ from test_objects import DummyTTS, DummyTTSValidator
 
 
 class TTSBaseClassTests(unittest.TestCase):
+    lang = "en-us"
+    config = {"g2p": {"module": "dummy"}}
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.test_cache_dir = join(dirname(__file__), "test_cache")
         cls.test_conf_dir = join(dirname(__file__), "config")
         os.makedirs(cls.test_conf_dir, exist_ok=True)
         os.environ["XDG_CACHE_HOME"] = cls.test_cache_dir
-        cls.config = {"key": "val"}
-        cls.lang = "en-us"
+
         cls.tts = WrappedTTS(DummyTTS, cls.lang, cls.config)
         bus = FakeBus()
         bus.connected_event = Event()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -51,12 +51,12 @@ from test_objects import DummyTTS, DummyTTSValidator
 
 class TTSBaseClassTests(unittest.TestCase):
     lang = "en-us"
-    config = {"g2p": {"module": "dummy"}}
+    config = {"key": "val"}
+    test_cache_dir = join(dirname(__file__), "test_cache")
+    test_conf_dir = join(dirname(__file__), "config")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.test_cache_dir = join(dirname(__file__), "test_cache")
-        cls.test_conf_dir = join(dirname(__file__), "config")
         os.makedirs(cls.test_conf_dir, exist_ok=True)
         os.environ["XDG_CACHE_HOME"] = cls.test_cache_dir
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -166,7 +166,9 @@ class TTSBaseClassTests(unittest.TestCase):
         self.assertTrue(self.tts.validator.validate_dependencies())
         self.assertTrue(self.tts.validator.validate_connection())
 
-    def test_validator_invalid(self):
+    @patch("ovos_plugin_manager.templates.tts.Configuration")
+    def test_validator_invalid(self, config):
+        config.return_value = self.config  # Explicitly no g2p
         tts = DummyTTS("es", {})
 
         with self.assertRaises(Exception):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -40,8 +40,6 @@ from ovos_bus_client import Message
 from ovos_plugin_manager.templates.tts import PlaybackThread
 from ovos_utils.messagebus import FakeBus
 
-from neon_utils.signal_utils import check_for_signal
-
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 from neon_audio.tts import WrappedTTS
 
@@ -54,6 +52,9 @@ class TTSBaseClassTests(unittest.TestCase):
     config = {"key": "val"}
     test_cache_dir = join(dirname(__file__), "test_cache")
     test_conf_dir = join(dirname(__file__), "config")
+    bus = FakeBus()
+    bus.connected_event = Event()
+    bus.connected_event.set()
 
     @classmethod
     @patch("ovos_plugin_manager.templates.tts.Configuration")
@@ -63,10 +64,7 @@ class TTSBaseClassTests(unittest.TestCase):
         os.environ["XDG_CACHE_HOME"] = cls.test_cache_dir
 
         cls.tts = WrappedTTS(DummyTTS, cls.lang, cls.config)
-        bus = FakeBus()
-        bus.connected_event = Event()
-        bus.connected_event.set()
-        cls.tts.init(bus)
+        cls.tts.init(cls.bus)
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -123,6 +121,8 @@ class TTSBaseClassTests(unittest.TestCase):
         self.assertEqual(self.tts._preprocess_sentence(sentence), [sentence])
 
     def test_execute(self):
+        from neon_utils.signal_utils import check_for_signal, init_signal_bus
+        init_signal_bus(self.bus)
         sentence = "testing"
         ident = time()
         default_execute = self.tts._execute


### PR DESCRIPTION
# Description
Newer ovos-audio module overrides `ident` in message_data in a way that is incompatible with Neon's handling of audio events

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->