### PR TITLE
Update timing context for non-Neon skills

### DIFF
--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -25,6 +25,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from time import time
 
 import ovos_audio.tts
 import ovos_plugin_manager.templates.tts
@@ -111,6 +112,8 @@ class NeonPlaybackService(PlaybackService):
 
         audio_finished = Event()
 
+        message.context.setdefault("timing", dict())
+        message.context["timing"].setdefault("speech_start", time())
         ident = message.data.get('speak_ident') or message.context.get('ident')
         if not ident:
             LOG.warning(f"Ident missing for speak: {message.data}")


### PR DESCRIPTION
# Description
Add default `speech_start` timing context for non-Neon skill metrics

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->