### PR TITLE
Add timing metrics for response to handler in MQ client

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
+    with:
+      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-ocp|bitstruct|audioread).*'

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -31,6 +31,8 @@ import inspect
 import os
 
 from os.path import dirname
+from time import time
+
 from json_database import JsonStorageXDG
 from ovos_bus_client.message import Message
 from ovos_plugin_manager.language import OVOSLangDetectionFactory,\
@@ -339,6 +341,7 @@ class WrappedTTS(TTS):
             # TODO dedicated klat handler/plugin
             if "klat_data" in message.context:
                 LOG.info("Sending klat.response")
+                message.context['timing']['response_sent'] = time()
                 self.bus.emit(
                     message.forward("klat.response",
                                     {"responses": responses,


### PR DESCRIPTION
# Description
Adds a timestamp when response is emitted for clients to calculate how long it takes to be handled

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
https://github.com/NeonGeckoCom/neon_speech/pull/181