### PR TITLE
Response timing and MQ fixes

### DIFF
--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -163,6 +163,7 @@ class NeonPlaybackService(PlaybackService):
         message.context.setdefault('timing', dict())
         if text:
             if not isinstance(text, str):
+                message.context['timing']['response_sent'] = time()
                 self.bus.emit(message.reply(
                     ident, data={"error": f"text is not a str: {text}"}))
                 return

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -145,7 +145,7 @@ class NeonPlaybackService(PlaybackService):
         if not audio_finished.wait(self._playback_timeout):
             LOG.warning(f"Playback not completed for {speak_id} within "
                         f"{self._playback_timeout} seconds")
-            self.bus.remove_all_listeners(speak_id)
+            self.bus.remove(speak_id, handle_finished)
         elif speak_id:
             LOG.debug(f"Playback completed for: {speak_id}")
 

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -134,6 +134,8 @@ class NeonPlaybackService(PlaybackService):
 
         def handle_finished(_):
             audio_finished.set()
+
+        # If we have an identifier, add a callback to wait for playback
         if speak_id:
             self.bus.once(speak_id, handle_finished)
         else:
@@ -143,6 +145,7 @@ class NeonPlaybackService(PlaybackService):
         if not audio_finished.wait(self._playback_timeout):
             LOG.warning(f"Playback not completed for {speak_id} within "
                         f"{self._playback_timeout} seconds")
+            self.bus.remove_all_listeners(speak_id)
         elif speak_id:
             LOG.debug(f"Playback completed for: {speak_id}")
 
@@ -157,6 +160,7 @@ class NeonPlaybackService(PlaybackService):
         if not message.data.get("speaker"):
             LOG.info(f"No speaker data with request, "
                      f"core defaults will be used.")
+        message.context.setdefault('timing', dict())
         if text:
             if not isinstance(text, str):
                 self.bus.emit(message.reply(
@@ -165,14 +169,16 @@ class NeonPlaybackService(PlaybackService):
             try:
                 with self._stopwatch:
                     responses = self.tts.get_multiple_tts(message)
-                message.context.setdefault('timing', dict())
                 message.context['timing']['get_tts'] = self._stopwatch.time
                 LOG.debug(f"Emitting response: {responses}")
+                message.context['timing']['response_sent'] = time()
                 self.bus.emit(message.reply(ident, data=responses))
             except Exception as e:
                 LOG.exception(e)
+                message.context['timing']['response_sent'] = time()
                 self.bus.emit(message.reply(ident, data={"error": repr(e)}))
         else:
+            message.context['timing']['response_sent'] = time()
             self.bus.emit(message.reply(ident,
                                         data={"error": "No text provided."}))
 

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -86,9 +86,13 @@ class TestAPIMethods(unittest.TestCase):
                    "ident": "123",
                    "user": "TestRunner"}
         tts_resp = self.bus.wait_for_response(Message("neon.get_tts", {},
-                                                      context),
+                                                      dict(context)),
                                               context["ident"])
-        self.assertEqual(tts_resp.context, context)
+        for key in context:
+            if key != "timing":
+                self.assertEqual(context[key], tts_resp.context[key])
+        self.assertIsInstance(tts_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(tts_resp.data.get("error"), str)
         self.assertEqual(tts_resp.data["error"], "No text provided.")
 
@@ -97,9 +101,13 @@ class TestAPIMethods(unittest.TestCase):
                    "ident": "1234",
                    "user": "TestRunner"}
         tts_resp = self.bus.wait_for_response(Message("neon.get_tts",
-                                                      {"text": 123}, context),
+                                                      {"text": 123},
+                                                      dict(context)),
                                               context["ident"], timeout=60)
-        self.assertEqual(tts_resp.context, context)
+        for key in context:
+            self.assertEqual(context[key], tts_resp.context[key])
+        self.assertIsInstance(tts_resp.context['timing']['response_sent'],
+                              float)
         self.assertTrue(tts_resp.data.get("error")
                         .startswith("text is not a str:"))
 
@@ -109,9 +117,13 @@ class TestAPIMethods(unittest.TestCase):
                    "ident": str(time()),
                    "user": "TestRunner"}
         tts_resp = self.bus.wait_for_response(Message("neon.get_tts",
-                                                      {"text": text}, context),
+                                                      {"text": text},
+                                                      dict(context)),
                                               context["ident"], timeout=60)
-        self.assertEqual(tts_resp.context, context)
+        for key in context:
+            self.assertEqual(context[key], tts_resp.context[key])
+        self.assertIsInstance(tts_resp.context['timing']['response_sent'],
+                              float)
         responses = tts_resp.data
         self.assertIsInstance(responses, dict)
         print(responses)

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -92,7 +92,7 @@ class TestAPIMethods(unittest.TestCase):
             if key != "timing":
                 self.assertEqual(context[key], tts_resp.context[key])
         self.assertIsInstance(tts_resp.context['timing']['response_sent'],
-                              float)
+                              float, tts_resp.context['timing'])
         self.assertIsInstance(tts_resp.data.get("error"), str)
         self.assertEqual(tts_resp.data["error"], "No text provided.")
 
@@ -107,7 +107,7 @@ class TestAPIMethods(unittest.TestCase):
         for key in context:
             self.assertEqual(context[key], tts_resp.context[key])
         self.assertIsInstance(tts_resp.context['timing']['response_sent'],
-                              float)
+                              float, tts_resp.context['timing'])
         self.assertTrue(tts_resp.data.get("error")
                         .startswith("text is not a str:"))
 
@@ -123,7 +123,7 @@ class TestAPIMethods(unittest.TestCase):
         for key in context:
             self.assertEqual(context[key], tts_resp.context[key])
         self.assertIsInstance(tts_resp.context['timing']['response_sent'],
-                              float)
+                              float, tts_resp.context['timing'])
         responses = tts_resp.data
         self.assertIsInstance(responses, dict)
         print(responses)


### PR DESCRIPTION
# Description
Fix speak_ident handling for `klat.response` events
Add `response_sent` timing context to API methods
Remove listener for incomplete audio playback

# Issues
Continues #154

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->