### PR TITLE
feat: expands entry point to install dependencies from extra_dependencies config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+__pycache__
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN pip install wheel && \
 COPY docker_overlay/ /
 RUN chmod ugo+x /root/run.sh
 
-RUN neon-audio install-plugin -f
+RUN neon-audio install-dependencies
 
 CMD ["/root/run.sh"]
 

--- a/docker_overlay/root/run.sh
+++ b/docker_overlay/root/run.sh
@@ -28,5 +28,5 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Plugin installation must occur in a separate thread, before module load, for the entry point to be loaded.
-neon-audio install-plugin -f
+neon-audio install-dependencies
 neon-audio run

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ ovos-utils~=0.0.35
 ovos-config~=0.0.10
 phoneme-guesser~=0.1
 ovos-plugin-manager~=0.0.24
-neon-utils[network]~=1.8
+neon-utils[network]~=1.8,>=1.8.3a5
 click~=8.0
 click-default-group~=1.2
 ovos-bus-client~=0.0.3


### PR DESCRIPTION
# Description
Once https://github.com/NeonGeckoCom/neon-utils/pull/499 is approved and merged I'll update the module requirements with a minimum neon-utils version.

- Expand the entrypoint with an additional command, "install-dependencies" command
- Add utility function for building a dependency list from extra_dependencies and modules or fallbacks specified in TTS configuration
- Mark neon_audio.utils.install_tts_plugin as deprecated

# Issues
https://github.com/NeonGeckoCom/neon_enclosure/issues/84

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->