### PR TITLE
Resolve PlaybackThread-related errors

### DIFF
--- a/neon_audio/__init__.py
+++ b/neon_audio/__init__.py
@@ -29,7 +29,5 @@
 # Patching deprecation warnings
 # TODO: Deprecate after migration to ovos-workshop 1.0+ requirement
 import ovos_workshop.resource_files
-import ovos_core.intent_services.stop_service
 from ovos_utils.bracket_expansion import expand_template
 ovos_workshop.resource_files.expand_options = expand_template
-ovos_core.intent_services.stop_service.expand_options = expand_template

--- a/neon_audio/__init__.py
+++ b/neon_audio/__init__.py
@@ -25,3 +25,11 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Patching deprecation warnings
+# TODO: Deprecate after migration to ovos-workshop 1.0+ requirement
+import ovos_workshop.resource_files
+import ovos_core.intent_services.stop_service
+from ovos_utils.bracket_expansion import expand_template
+ovos_workshop.resource_files.expand_options = expand_template
+ovos_core.intent_services.stop_service.expand_options = expand_template

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -93,10 +93,6 @@ class NeonPlaybackService(PlaybackService):
         PlaybackService.__init__(self, ready_hook, error_hook, stopping_hook,
                                  alive_hook, started_hook, watchdog, bus,
                                  disable_ocp, validate_source=False)
-        del self.playback_thread
-        from neon_audio.tts.neon import NeonPlaybackThread
-        from ovos_plugin_manager.tts import TTS
-        self.playback_thread = NeonPlaybackThread(TTS.queue, self.bus)
         LOG.debug(f'Initialized tts={self._tts_hash} | '
                   f'fallback={self._fallback_tts_hash}')
         create_signal("neon_speak_api")   # Create signal so skills use API

--- a/neon_audio/service.py
+++ b/neon_audio/service.py
@@ -80,13 +80,16 @@ class NeonPlaybackService(PlaybackService):
         :param bus: Connected MessageBusClient
         :param disable_ocp: if True, disable OVOS Common Play service
         """
+        from neon_utils.signal_utils import create_signal
+        # Patch import so PlaybackService creates a `NeonPlaybackThread` object
+        from neon_audio.tts.neon import NeonPlaybackThread
+        ovos_audio.service.PlaybackThread = NeonPlaybackThread
+
         if audio_config:
             LOG.info("Updating global config with passed config")
             from neon_audio.utils import patch_config
             patch_config(audio_config)
         bus = bus or get_messagebus()
-        from neon_utils.signal_utils import create_signal
-
         PlaybackService.__init__(self, ready_hook, error_hook, stopping_hook,
                                  alive_hook, started_hook, watchdog, bus,
                                  disable_ocp, validate_source=False)

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -31,6 +31,7 @@ import inspect
 import os
 
 from os.path import dirname
+from pathlib import Path
 from time import time
 from typing import List
 
@@ -340,8 +341,7 @@ class WrappedTTS(TTS):
                 tx_sentence = sentence
             kwargs['speaker'] = request
             audio_obj, phonemes = self.synth(tx_sentence, **kwargs)
-            wav_file = audio_obj.path
-
+            wav_file = str(audio_obj)
             # If this is the first response, populate translation and phonemes
             responses.setdefault(tts_lang, {"sentence": tx_sentence,
                                             "translated": tx_sentence != sentence,

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -215,6 +215,7 @@ class NeonPlaybackThread(PlaybackThread):
                 LOG.debug(f"START PLAYBACK")
                 self._now_playing = (data, visemes, listen, tts_id, message)
                 self._play()
+                assert self._now_playing is None
                 LOG.debug("END PLAYBACK")
             except Empty:
                 pass
@@ -281,6 +282,10 @@ class WrappedTTS(TTS):
             TTS.playback.shutdown()
         if not isinstance(playback_thread, NeonPlaybackThread):
             LOG.exception(f"Received invalid playback_thread: {playback_thread}")
+            if isinstance(playback_thread, PlaybackThread):
+                LOG.warning(f"Joining {playback_thread}")
+                playback_thread.stop()
+                playback_thread.join()
             playback_thread = None
         init_signal_bus(self.bus)
         TTS.playback = playback_thread or NeonPlaybackThread(TTS.queue)

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -201,6 +201,10 @@ class NeonPlaybackThread(PlaybackThread):
         LOG.debug(f"Playback thread resumed")
         PlaybackThread.resume(self)
 
+    def run(self, *args, **kwargs):
+        LOG.info("Playback thread started")
+        PlaybackThread.run(self, *args, **kwargs)
+
 
 class WrappedTTS(TTS):
     def __new__(cls, base_engine, *args, **kwargs):
@@ -260,7 +264,7 @@ class WrappedTTS(TTS):
                 return
             TTS.playback.shutdown()
         if not isinstance(playback_thread, NeonPlaybackThread):
-            LOG.exception("Received invalid playback_thread")
+            LOG.exception(f"Received invalid playback_thread: {playback_thread}")
             playback_thread = None
         init_signal_bus(self.bus)
         TTS.playback = playback_thread or NeonPlaybackThread(TTS.queue)

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -281,7 +281,8 @@ class WrappedTTS(TTS):
                 LOG.exception("Error starting the playback thread")
 
     def _get_tts(self, sentence: str, request: dict = None, **kwargs):
-        # TODO: Signature should be made to match ovos-audio
+        log_deprecation("This method is deprecated without replacement",
+                        "1.6.0")
         if any([x in inspect.signature(self.get_tts).parameters
                 for x in {"speaker", "wav_file"}]):
             LOG.info(f"Legacy Neon TTS signature found ({self.__class__.__name__})")
@@ -294,7 +295,6 @@ class WrappedTTS(TTS):
             os.makedirs(dirname(file), exist_ok=True)
             if os.path.isfile(file):
                 LOG.info(f"Using cached TTS audio")
-                # TODO: In this case, playback is not reported properly
                 return file, None
             plugin_kwargs = dict()
             if "speaker" in inspect.signature(self.get_tts).parameters:
@@ -421,11 +421,8 @@ class WrappedTTS(TTS):
                         vis = self.viseme(r["phonemes"]) if r["phonemes"] \
                             else None
                         # queue for playback
-                        LOG.debug(f"Queue playback of: {wav_file} in "
-                                  f"queue={self.queue}")
-                        element = (wav_file, vis, listen, ident, message)
-                        LOG.debug(f"Queue element={element}")
-                        self.queue.put(element)
+                        LOG.debug(f"Queue playback of: {wav_file}")
+                        self.queue.put((wav_file, vis, listen, ident, message))
                         self.handle_metric({"metric_type": "tts.queued"})
         else:
             LOG.warning(f'no Message associated with TTS request: {ident}')

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -209,7 +209,7 @@ class WrappedTTS(TTS):
         base_engine.execute = cls.execute
         base_engine.get_multiple_tts = cls.get_multiple_tts
         # TODO: Below method is only to bridge compatibility
-        # base_engine._get_tts = cls._get_tts
+        base_engine._get_tts = cls._get_tts
         base_engine._init_playback = cls._init_playback
         base_engine.lang = cls.lang
         return cls._init_neon(base_engine, *args, **kwargs)

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -31,7 +31,6 @@ import inspect
 import os
 
 from os.path import dirname
-from queue import Empty
 from time import time
 from typing import List
 
@@ -174,7 +173,6 @@ class NeonPlaybackThread(PlaybackThread):
         check_for_signal("isSpeaking")
 
     def _play(self):
-        # TODO Not called?
         LOG.debug(f"Start playing {self._now_playing} from queue={self.queue}")
         # wav_file, vis, listen, ident, message
         ident = self._now_playing[3]
@@ -203,24 +201,6 @@ class NeonPlaybackThread(PlaybackThread):
     def resume(self):
         LOG.debug(f"Playback thread resumed")
         PlaybackThread.resume(self)
-
-    def run(self, cb=None):
-        LOG.info("PlaybackThread started")
-        self._do_playback.set()
-        self._started.set()
-        while not self._terminated:
-            self._do_playback.wait()
-            try:
-                data, visemes, listen, tts_id, message = self.queue.get(timeout=2)
-                LOG.debug(f"START PLAYBACK")
-                self._now_playing = (data, visemes, listen, tts_id, message)
-                self._play()
-                assert self._now_playing is None
-                LOG.debug("END PLAYBACK")
-            except Empty:
-                pass
-            except Exception as e:
-                LOG.error(e)
 
 
 class WrappedTTS(TTS):

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -154,7 +154,7 @@ def _sort_timing_metrics(timings: dict) -> dict:
 
 class NeonPlaybackThread(PlaybackThread):
     def __init__(self, queue, bus=None):
-        LOG.info("Initializing NeonPlaybackThread")
+        LOG.info(f"Initializing NeonPlaybackThread with queue={queue}")
         PlaybackThread.__init__(self, queue, bus=bus)
 
     def begin_audio(self, message: Message = None):
@@ -174,7 +174,8 @@ class NeonPlaybackThread(PlaybackThread):
         check_for_signal("isSpeaking")
 
     def _play(self):
-        LOG.debug(f"Start playing {self._now_playing}")
+        # TODO Not called?
+        LOG.debug(f"Start playing {self._now_playing} from queue={self.queue}")
         # wav_file, vis, listen, ident, message
         ident = self._now_playing[3]
         message = self._now_playing[4]
@@ -422,7 +423,8 @@ class WrappedTTS(TTS):
                         vis = self.viseme(r["phonemes"]) if r["phonemes"] \
                             else None
                         # queue for playback
-                        LOG.debug(f"Queue playback of: {wav_file}")
+                        LOG.debug(f"Queue playback of: {wav_file} in "
+                                  f"queue={self.queue}")
                         self.queue.put((wav_file, vis, listen, ident, message))
                         self.handle_metric({"metric_type": "tts.queued"})
         else:

--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -31,19 +31,15 @@ import inspect
 import os
 
 from os.path import dirname
-from queue import Empty
 from time import time
 from typing import List
 
 from json_database import JsonStorageXDG
 from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_bus_client.message import Message
-from ovos_bus_client.util import get_message_lang
 from ovos_plugin_manager.language import OVOSLangDetectionFactory,\
     OVOSLangTranslationFactory
-from ovos_plugin_manager.templates.g2p import OutOfVocabulary
-from ovos_plugin_manager.templates.tts import TTS, TTSContext
-from ovos_utils.sound import play_audio
+from ovos_plugin_manager.templates.tts import TTS
 
 from neon_utils.file_utils import encode_file_to_base64_string
 from neon_utils.message_utils import resolve_message
@@ -343,7 +339,8 @@ class WrappedTTS(TTS):
             else:
                 tx_sentence = sentence
             kwargs['speaker'] = request
-            wav_file, phonemes = self.synth(tx_sentence, **kwargs)
+            audio_obj, phonemes = self.synth(tx_sentence, **kwargs)
+            wav_file = audio_obj.path
 
             # If this is the first response, populate translation and phonemes
             responses.setdefault(tts_lang, {"sentence": tx_sentence,

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -182,6 +182,7 @@ class TTSBaseClassTests(unittest.TestCase):
         tts.shutdown()
 
     def test_get_tts(self):
+        # TODO: Deprecate
         test_file_path = join(dirname(__file__), "test.wav")
         file, phonemes = self.tts._get_tts("test", wav_file=test_file_path,
                                            speaker={})


### PR DESCRIPTION
# Description
Refactor to prevent duplicated `PlaybackThread` instances
Patch out ovos_utils/ovos_workshop deprecation warnings that affect versions currently incompatible with this package
Refactor to implement upstream `synth` method and drop internal `_get_tts` method

# Issues
- Refactoring on `ovos_audio` possibly closes #140

# Other Notes
Resolves observed Mark2 issues where `wait_while_speaking` sometimes times out without a response from the Audio service