### PR TITLE
Update `run` entrypoint to account for deprecated methods

### DIFF
--- a/neon_audio/cli.py
+++ b/neon_audio/cli.py
@@ -61,15 +61,16 @@ def neon_audio_cli(version: bool = False):
 def run(module, package, force_install):
     from neon_audio.__main__ import main
     if force_install or module or package:
-        install_plugin(module, package, force_install)
+        try:
+            install_plugin(module, package, force_install)
+        except Exception as e:
+            click.echo(f"Failed to install plugin: {e}")
     if module:
         audio_config = Configuration()
         if module != audio_config["tts"]["module"]:
-            from neon_audio.utils import patch_config
-            click.echo("Updating config with module and package")
-            package = package or audio_config["tts"].get("package_spec")
-            patch_config({"tts": {"module": module,
-                                  "package_spec": package}})
+            LOG.warning(f"Requested a module to install ({module}), but config "
+                        f"specifies {audio_config['tts']['module']}. Configured"
+                        " module will be loaded.")
     click.echo("Starting Audio Client")
     main()
     click.echo("Audio Client Shutdown")


### PR DESCRIPTION
# Description
Add explicit exception handling around `install_plugin` call from `run` command
Log a warning instead of patching configuration when a module is passed to `run` that does not match configuration 

# Issues
Closes #167

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->