### PR TITLE
Refactor to include audio data for all MQ-originated requests

### DIFF
--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -352,7 +352,7 @@ class WrappedTTS(TTS):
                 responses[tts_lang][request["gender"]] = wav_file
                 responses[tts_lang]["genders"].append(request["gender"])
                 # If this is a remote request, encode audio in the response
-                if message.context.get("klat_data") or \
+                if message.context.get("mq") or \
                         message.msg_type == "neon.get_tts":
                     responses[tts_lang].setdefault("audio", {})
                     responses[tts_lang]["audio"][request["gender"]] = \


### PR DESCRIPTION
# Description
Replace check for `klat_data` context with `mq` context to include encoded audio in responses to other clients (i.e. Gradio)

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Currently works because the messagebus-mq connector module [guarantees Klat context](https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/blob/65192ecdd9f896799a2be3a9a76bdffa566c9527/neon_messagebus_mq_connector/controller.py#L313-L320) for any MQ messages received