### PR TITLE
feat: disable mpris by default in neon-audio containers

### DIFF
--- a/docker_overlay/etc/neon/neon.yaml
+++ b/docker_overlay/etc/neon/neon.yaml
@@ -12,6 +12,7 @@ Audio:
       type: ovos_common_play
       active: true
       dbus_type: system
+      disable_mpris: true
     simple:
       type: ovos_audio_simple
       active: true


### PR DESCRIPTION
Closes #77

# Description
Disables MPRIS in neon-audio containers by default

# Issues
#77

# Other Notes
```python
❯ docker compose up
[+] Running 2/2
 ✔ Container neon-messagebus  Created                                                                                                         0.0s 
 ✔ Container neon-audio       Recreated                                                                                                       0.1s 
Attaching to neon-audio, neon-messagebus
neon-messagebus  | Starting Messagebus Service
neon-messagebus  | 2025-10-06 22:11:59.854 - bus - neon_utils.process_utils:start_health_check_server:155 - INFO - Started health check endpoint at ('0.0.0.0', 8000)
neon-messagebus  | 2025-10-06 22:11:59.854 - bus - neon_messagebus.service:run:116 - INFO - Starting message bus service...
neon-messagebus  | 2025-10-06 22:11:59.855 - bus - ovos_messagebus.load_config:load_message_bus_config:33 - INFO - Loading message bus configs
neon-messagebus  | 2025-10-06 22:11:59.855 - bus - neon_messagebus.service:_listen:193 - INFO - Starting Messagebus server with config: MessageBusConfig(host='0.0.0.0', port=8181, route='/core', ssl=None)
neon-messagebus  | 2025-10-06 22:11:59.855 - bus - neon_messagebus.service:_listen:209 - INFO - ws listener started
neon-messagebus  | [I 251006 22:11:59 web:2407] 101 GET /core (127.0.0.1) 0.21ms
neon-messagebus  | [I 251006 22:11:59 _logging:89] Websocket connected
neon-messagebus  | 2025-10-06 22:11:59.859 - bus - neon_messagebus.service:_init_signal_manager:157 - INFO - Signal Manager started
neon-messagebus  | 2025-10-06 22:11:59.859 - bus - neon_messagebus.service:_init_mq_connector:161 - INFO - No MQ Configuration
neon-messagebus  | 2025-10-06 22:11:59.860 - bus - neon_messagebus.service:on_ready:50 - INFO - Messagebus is ready.
neon-messagebus  | 2025-10-06 22:11:59.860 - bus - neon_messagebus.service:run:128 - INFO - Message bus service started!
neon-audio       | 2025-10-06 22:11:59.946 - neon-utils - neon_audio.utils:build_extra_dependency_list:85 - WARNING - Deprecation version=2.0.0. Caller=neon_audio.cli:159. `module` will no longer be installed. Add dependencies to Configuration.extra_dependencies.audio
neon-audio       | 2025-10-06 22:11:59.948 - neon-utils - neon_utils.packaging_utils:install_packages_from_pip:262 - INFO - Constraints=ovos-audio~=0.3
neon-audio       | ovos-utils>=0.0.35,~=0.0
neon-audio       | ovos-config~=0.1
neon-audio       | phoneme-guesser~=0.1
neon-audio       | ovos-plugin-manager~=0.1
neon-audio       | neon-utils
neon-audio       | click~=8.0
neon-audio       | click-default-group~=1.2
neon-audio       | ovos-bus-client>=0.0.3,~=0.0
neon-audio       | ovos-audio-plugin-simple~=0.1
neon-audio       | ovos-plugin-common-play>=0.0.6,~=0.0
neon-audio       | ovos-ocp-m3u-plugin>=0.0.1,~=0.0
neon-audio       | ovos-ocp-rss-plugin>=0.0.2,~=0.0
neon-audio       | ovos-ocp-files-plugin~=0.13
neon-audio       | ovos-ocp-news-plugin>=0.0.3,~=0.0
neon-audio       | neon-lang-plugin-libretranslate>=0.2.1,~=0.2
neon-audio       | ovos-tts-plugin-mimic~=0.2
neon-audio       | neon-tts-plugin-coqui>=0.8.1,~=0.7
neon-audio       | 2025-10-06 22:11:59.948 - neon-utils - neon_utils.packaging_utils:install_packages_from_pip:268 - INFO - Requested installation of plugins: ['coqui']
neon-audio       | Requirement already satisfied: coqui in /usr/local/lib/python3.10/site-packages (from -r /tmp/tmp21wgpbvy (line 1)) (0.0.10)
neon-audio       | Requirement already satisfied: gql[aiohttp]==3.3.0 in /usr/local/lib/python3.10/site-packages (from coqui->-r /tmp/tmp21wgpbvy (line 1)) (3.3.0)
neon-audio       | Requirement already satisfied: json5==0.9.8 in /usr/local/lib/python3.10/site-packages (from coqui->-r /tmp/tmp21wgpbvy (line 1)) (0.9.8)
neon-audio       | Requirement already satisfied: click==8.1.3 in /usr/local/lib/python3.10/site-packages (from coqui->-r /tmp/tmp21wgpbvy (line 1)) (8.1.3)
neon-audio       | Requirement already satisfied: graphql-core<3.3,>=3.2 in /usr/local/lib/python3.10/site-packages (from gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (3.2.6)
neon-audio       | Requirement already satisfied: yarl<2.0,>=1.6 in /usr/local/lib/python3.10/site-packages (from gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (1.22.0)
neon-audio       | Requirement already satisfied: aiohttp<3.9.0,>=3.7.1 in /usr/local/lib/python3.10/site-packages (from gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (3.8.6)
neon-audio       | Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/site-packages (from aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (1.4.0)
neon-audio       | Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/site-packages (from aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (6.7.0)
neon-audio       | Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /usr/local/lib/python3.10/site-packages (from aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (4.0.3)
neon-audio       | Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/site-packages (from aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (1.8.0)
neon-audio       | Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /usr/local/lib/python3.10/site-packages (from aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (3.4.3)
neon-audio       | Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/site-packages (from aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (25.4.0)
neon-audio       | Requirement already satisfied: propcache>=0.2.1 in /usr/local/lib/python3.10/site-packages (from yarl<2.0,>=1.6->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (0.4.0)
neon-audio       | Requirement already satisfied: idna>=2.0 in /usr/local/lib/python3.10/site-packages (from yarl<2.0,>=1.6->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (3.10)
neon-audio       | Requirement already satisfied: typing-extensions>=4.2 in /usr/local/lib/python3.10/site-packages (from aiosignal>=1.1.2->aiohttp<3.9.0,>=3.7.1->gql[aiohttp]==3.3.0->coqui->-r /tmp/tmp21wgpbvy (line 1)) (4.15.0)
neon-audio       | WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
neon-audio       | 
neon-audio       | [notice] A new release of pip is available: 23.0.1 -> 25.2
neon-audio       | [notice] To update, run: pip install --upgrade pip
neon-audio       | 2025-10-06 22:12:00.432 - neon-utils - neon_audio.cli:install_dependencies:161 - INFO - pip exit code: False
neon-audio       | Starting Audio Client
neon-messagebus  | [I 251006 22:12:00 web:2407] 101 GET /core (172.22.0.3) 0.26ms
neon-audio       | 2025-10-06 22:12:00.771 - audio - neon_utils.signal_utils:init_signal_handlers:117 - INFO - Signal Manager Available
neon-audio       | 2025-10-06 22:12:00.771 - audio - neon_utils.signal_utils:init_signal_handlers:124 - WARNING - Deprecation version=2.0.0. Caller=neon_audio.__main__:64. Import patching will be deprecated. Disable in configuration by setting `signal`.`patch_imports` to `False`
neon-audio       | 2025-10-06 22:12:00.822 - audio - ovos_audio.service:__init__:63 - INFO - Starting Audio Service
neon-audio       | 2025-10-06 22:12:01.506 - audio - neon_audio.service:init_messagebus:208 - INFO - Initialized messagebus
neon-audio       | 2025-10-06 22:12:01.536 - audio - neon_audio.tts.neon:__init__:156 - INFO - Initializing NeonPlaybackThread with queue=<queue.Queue object at 0xffff90805870>
neon-audio       | 2025-10-06 22:12:01.543 - audio - ovos_audio.playback:run:174 - INFO - PlaybackThread started
neon-audio       | 2025-10-06 22:12:01.543 - audio - ovos_audio.service:_maybe_reload_tts:379 - INFO - (re)loading TTS engine
neon-audio       | 2025-10-06 22:12:02.241 - audio - neon_audio.tts.neon:__new__:208 - INFO - Creating wrapped TTS object for <class 'neon_tts_plugin_coqui.CoquiTTS'>
neon-audio       | 2025-10-06 22:12:02.242 - audio - ovos_plugin_manager.templates.tts:__init__:231 - WARNING - Deprecation version=Unknown. Caller=neon_tts_plugin_coqui:63. lang argument for TTS has been deprecated! it will be ignored, pass lang to get_tts directly instead
neon-audio       | 2025-10-06 22:12:02.244 - audio - neon_tts_plugin_coqui:_init_model:187 - INFO - Initializing model for: en
neon-audio       | /usr/local/lib/python3.10/site-packages/torch/package/package_importer.py:235: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
neon-audio       |   dtype = storage_type.dtype
neon-audio       | 2025-10-06 22:12:03.331 - audio - ovos_plugin_manager.language:create:131 - INFO - Loaded the Language Detection plugin libretranslate_detection_plug
neon-audio       | 2025-10-06 22:12:03.334 - audio - ovos_plugin_manager.language:create:188 - INFO - Loaded the Language Translation plugin libretranslate_plug
neon-audio       | 2025-10-06 22:12:03.337 - audio - neon_audio.tts:create:62 - INFO - Initialized tts: CoquiTTS
neon-audio       | 2025-10-06 22:12:03.337 - audio - ovos_audio.service:_maybe_reload_tts:403 - INFO - (re)loading fallback TTS engine
neon-audio       | 2025-10-06 22:12:03.339 - audio - neon_audio.tts.neon:__new__:208 - INFO - Creating wrapped TTS object for <class 'ovos_tts_plugin_mimic.MimicTTSPlugin'>
neon-audio       | 2025-10-06 22:12:03.341 - audio - ovos_plugin_manager.templates.tts:__init__:231 - WARNING - Deprecation version=Unknown. Caller=ovos_tts_plugin_mimic:83. lang argument for TTS has been deprecated! it will be ignored, pass lang to get_tts directly instead
neon-audio       | 2025-10-06 22:12:03.344 - audio - ovos_plugin_manager.language:create:131 - INFO - Loaded the Language Detection plugin libretranslate_detection_plug
neon-audio       | 2025-10-06 22:12:03.347 - audio - ovos_plugin_manager.language:create:188 - INFO - Loaded the Language Translation plugin libretranslate_plug
neon-audio       | 2025-10-06 22:12:03.348 - audio - neon_audio.tts:create:62 - INFO - Initialized tts: MimicTTSPlugin
neon-audio       | 2025-10-06 22:12:03.348 - audio - neon_audio.tts.neon:_init_playback:260 - WARNING - Playback already initialized. skipping init
neon-audio       | 2025-10-06 22:12:03.381 - audio - ovos_utils.messagebus:<module>:5 - WARNING - Deprecation version=1.0.0. Caller=ovos_plugin_common_play.ocp.player:10. ovos_utils.messagebus has been deprecated since version 0.1.0!! please import from ovos_utils.fakebus or ovos_bus_client directly
neon-audio       | 2025-10-06 22:12:03.399 - audio - ovos_audio.audio:load_services:145 - INFO - Found audio service plugin: ovos_audio_simple
neon-audio       | 2025-10-06 22:12:06.505 - ovos.common_play - INFO - First run of ovos.common_play
neon-audio       | 2025-10-06 22:12:06.644 - audio - ovos_plugin_common_play.ocp.player:__init__:61 - INFO - MPRIS integration is disabled
neon-audio       | 2025-10-06 22:12:06.646 - audio - ovos_plugin_common_play.ocp:__init__:71 - INFO - Using Classic OCP with experimental OCP pipeline
neon-audio       | 2025-10-06 22:12:06.647 - audio - ovos_utils.fakebus:__new__:341 - WARNING - Deprecation version=1.0.0. Caller=ovos_plugin_common_play.ocp:85. please import from ovos-bus-client directly! this import has been deprecated since version 0.1.0
neon-audio       | 2025-10-06 22:12:06.756 - audio - ovos_plugin_manager.ocp:load:70 - INFO - Loaded OCP plugin: ovos-ocp-rss-plugin
neon-audio       | 2025-10-06 22:12:06.756 - audio - ovos_plugin_manager.ocp:load:70 - INFO - Loaded OCP plugin: ovos-ocp-files-plugin
neon-audio       | 2025-10-06 22:12:06.756 - audio - ovos_plugin_manager.ocp:load:70 - INFO - Loaded OCP plugin: ovos-ocp-m3u-plugin
neon-audio       | 2025-10-06 22:12:06.757 - audio - ovos_plugin_manager.ocp:load:70 - INFO - Loaded OCP plugin: ovos-ocp-news-plugin
neon-audio       | 2025-10-06 22:12:06.757 - audio - ovos_audio.audio:find_default:122 - INFO - Finding default audio backend...
neon-audio       | 2025-10-06 22:12:06.758 - audio - ovos_audio.audio:find_default:130 - INFO - preferred audio player not configured, defaulting to <ovos_audio_plugin_simple.OVOSSimpleService object at 0xffff48dd6a40>
neon-audio       | 2025-10-06 22:12:06.801 - audio - neon_audio.__main__:main:72 - INFO - Service init completed
neon-audio       | 2025-10-06 22:12:06.809 - audio - neon_utils.process_utils:start_health_check_server:155 - INFO - Started health check endpoint at ('0.0.0.0', 8000)
neon-audio       | 2025-10-06 22:12:06.810 - audio - ovos_audio.service:run:269 - INFO - Legacy AudioService enabled
neon-audio       | 2025-10-06 22:12:06.810 - audio - ovos_audio.service:run:271 - WARNING - OCP has moved to ovos-media, if you already migrated to ovos-media set "disable_ocp": true in mycroft.conf
neon-audio       | 2025-10-06 22:12:06.927 - audio - neon_audio.service:on_ready:46 - INFO - Playback service is ready.
```
