### PR TITLE
Add expect_response to klat.response messages

### DIFF
--- a/neon_audio/tts/neon.py
+++ b/neon_audio/tts/neon.py
@@ -402,7 +402,8 @@ class WrappedTTS(TTS):
                 self.bus.emit(
                     message.forward("klat.response",
                                     {"responses": responses,
-                                     "speaker": message.data.get("speaker")}))
+                                     "speaker": message.data.get("speaker"),
+                                     "expect_response": listen}))
                 # Emit `ident` message to indicate this transaction is complete
                 LOG.debug(f"Notify playback completed for {ident}")
                 self.bus.emit(message.forward(ident))

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -151,6 +151,15 @@ class TTSBaseClassTests(unittest.TestCase):
         message.context['klat_data'] = dict()
         self.tts.execute(sentence, ident, message=message)
         klat_response.assert_called_once()
+        self.assertFalse(
+            klat_response.call_args[0][0].data['expect_response'])
+        # Check `listen` is forwarded so remote clients know to re-open the mic
+        klat_response.reset_mock()
+        self.tts.bus.once('klat.response', klat_response)
+        self.tts.execute(sentence, ident, listen=True, message=message)
+        klat_response.assert_called_once()
+        self.assertTrue(
+            klat_response.call_args[0][0].data['expect_response'])
         # Check not called without klat_data context
         self.tts.bus.once('klat.response', klat_response)
         message.context.pop('klat_data')


### PR DESCRIPTION
# Description

`speak` messages carry `expect_response`, which reaches `WrappedTTS.execute` as `listen` but is dropped when building `klat.response`. Local playback signals this via `mycroft.mic.listen` after TTS; klat/MQ sessions never reach that path, so remote clients (e.g. hana Node WebSocket) can't know a skill expects a reply. This breaks `get_response` and converse prompts for those clients.

Add `expect_response` to the `klat.response` payload so clients can trigger listening after playback.

# Issues

# Other Notes

Extended the existing `test_execute` klat assertions to cover the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
